### PR TITLE
Changes specific to the use with ESP32 MCUs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.errorSquiggles": "disabled"
+}

--- a/MCP23S08.cpp
+++ b/MCP23S08.cpp
@@ -29,13 +29,7 @@ void MCP23S08::begin() {
 
 	// enable chip hardware addresses
 	if (haen) {
-		spi.beginTransaction(spi_settings);
-		digitalWrite(csPin, LOW);
-		spi.transfer(0x40);  // command write, address 0 (hardware addressing is disabled on POR)
-		spi.transfer(MCP23S08_IOCON);
-		spi.transfer(0x08);
-		digitalWrite(csPin, HIGH);
-		spi.endTransaction();
+		writeRegister(MCP23S08_IOCON, MCP23S08_IOCON_HAEN);
 	}
 }
 
@@ -49,7 +43,7 @@ void MCP23S08::reset() {
 	spi.transfer(0xFF);				// reset first register
 	for (uint8_t i = 0; i < MCP23S08_OLAT; i++) {
 		if (haen && (MCP23S08_IOCON == i))
-			spi.transfer(0x08);			// enable hardware address (HAEN)
+			spi.transfer(MCP23S08_IOCON_HAEN);			// enable hardware address (HAEN)
 		else
 			spi.transfer(0x00);			// reset other 10 registers
 	}

--- a/MCP23S08.cpp
+++ b/MCP23S08.cpp
@@ -23,9 +23,11 @@ MCP23S08::MCP23S08(SPIClass & spi,
 
 
 void MCP23S08::begin() {
-	// Why do we initialize the pin here
-	// yet expect the spi bus to be initialized?
-	pinMode(csPin, OUTPUT);
+	/* Why do we initialize the pin here
+	yet expect the spi bus to be initialized?
+	Good question, not sure but, maybe the ESP32 SPI is not yet inialised.*/
+	
+	pinMode(csPin, OUTPUT);		// Required for ESP32 devices.
 
 	// enable chip hardware addresses
 	if (haen) {

--- a/MCP23S08.h
+++ b/MCP23S08.h
@@ -25,6 +25,7 @@
 #define MCP23S08_INTCAP		0x08
 #define MCP23S08_GPIO		0x09
 #define MCP23S08_OLAT		0x0A
+#define MCP23S08_IOCON_HAEN	0x08
 
 
 class MCP23S08 {

--- a/MCP23S08.h
+++ b/MCP23S08.h
@@ -10,6 +10,7 @@
 #ifndef __MCP23S08_h__
 #define __MCP23S08_h__
 
+#include "Arduino.h"
 #include <SPI.h>
 
 

--- a/MCP23S08.h
+++ b/MCP23S08.h
@@ -10,7 +10,7 @@
 #ifndef __MCP23S08_h__
 #define __MCP23S08_h__
 
-#include "Arduino.h"
+#include "Arduino.h"		// Required for ESP32 devices.
 #include <SPI.h>
 
 


### PR DESCRIPTION
The changes in this Pull request do not correct any errors or mistakes in the library but rather are made to enable the library to be used with ESP32 mcu's specifically. The library as it is, communicates correctly with all the registers including MCP23S08_IOCON.
